### PR TITLE
When parsing args, don't throw error for missing "soft" required args.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for CLI-Driver
 
+0.70 - Fix _get_val to not through error for missing required soft args
+
 0.69 - added link to source code on github (thanks to Gabor Szabo)
 
 0.68 - removed circular dependency on Util::Medley

--- a/lib/CLI/Driver.pm
+++ b/lib/CLI/Driver.pm
@@ -16,7 +16,7 @@ use CLI::Driver::Action;
 
 with 'CLI::Driver::CommonRole';
 
-our $VERSION = 0.69;
+our $VERSION = 0.70;
 
 =head1 SYNOPSIS
 

--- a/lib/CLI/Driver/Option.pm
+++ b/lib/CLI/Driver/Option.pm
@@ -166,7 +166,7 @@ method _get_val {
 		}
 
 		# we didn't find it in @ARGV
-		if ( $self->required ) {
+		if ( $self->is_hard && $self->required ) {
 			confess "failed to get arg from argv: $arg";
 		}
 	}


### PR DESCRIPTION
These are "soft" because the perl code should be providing or searching
for defaults in another manner and an error will be thrown if they
are not populated later in the process.